### PR TITLE
Remove path tag from default config

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -21,9 +21,6 @@ router:
     - heroku_name: method
       datadog_name: method
       type: string
-    - heroku_name: path
-      datadog_name: path
-      type: string
     - heroku_name: status
       datadog_name: status
       type: string

--- a/spec/heroku_drain_datadog/http/router_spec.rb
+++ b/spec/heroku_drain_datadog/http/router_spec.rb
@@ -82,11 +82,11 @@ RSpec.describe HerokuDrainDatadog::HTTP::Router do
           end
 
           it "sends a histogram for connect" do
-            expect(socket.buffer[0]).to eq("heroku.router.connect:0.0|h|#source:web.1,dynotype:web,method:GET,path:/assets/admin-62f13e9f7cb78a2b3e436feaedd07fd67b74cce818f3bb7cfdab1e1c05dc2f89.css,status:304")
+            expect(socket.buffer[0]).to eq("heroku.router.connect:0.0|h|#source:web.1,dynotype:web,method:GET,status:304")
           end
 
           it "sends a histogram for service" do
-            expect(socket.buffer[1]).to eq("heroku.router.service:2.0|h|#source:web.1,dynotype:web,method:GET,path:/assets/admin-62f13e9f7cb78a2b3e436feaedd07fd67b74cce818f3bb7cfdab1e1c05dc2f89.css,status:304")
+            expect(socket.buffer[1]).to eq("heroku.router.service:2.0|h|#source:web.1,dynotype:web,method:GET,status:304")
           end
 
           it "increments drain" do
@@ -273,14 +273,14 @@ RSpec.describe HerokuDrainDatadog::HTTP::Router do
           it "can be a single tag" do
             with_env("DRAIN_TAGS_FOR_abc123", "service:myapp") do
               post "/logs", %q{338 <158>1 2016-08-20T02:15:10.862264+00:00 host heroku router - at=info method=GET path="/assets/admin-62f13e9f7cb78a2b3e436feaedd07fd67b74cce818f3bb7cfdab1e1c05dc2f89.css" host=app.fivegoodfriends.com.au request_id=bef7f609-eceb-4684-90ce-c249e6843112 fwd="58.6.203.42,54.239.202.42" dyno=web.1 connect=0ms service=2ms status=304 bytes=112}
-              expect(socket.buffer[0]).to eq("heroku.router.connect:0.0|h|#service:myapp,source:web.1,dynotype:web,method:GET,path:/assets/admin-62f13e9f7cb78a2b3e436feaedd07fd67b74cce818f3bb7cfdab1e1c05dc2f89.css,status:304")
+              expect(socket.buffer[0]).to eq("heroku.router.connect:0.0|h|#service:myapp,source:web.1,dynotype:web,method:GET,status:304")
             end
           end
 
           it "can be many tags" do
             with_env("DRAIN_TAGS_FOR_abc123", "env:production,service:myapp") do
               post "/logs", %q{338 <158>1 2016-08-20T02:15:10.862264+00:00 host heroku router - at=info method=GET path="/assets/admin-62f13e9f7cb78a2b3e436feaedd07fd67b74cce818f3bb7cfdab1e1c05dc2f89.css" host=app.fivegoodfriends.com.au request_id=bef7f609-eceb-4684-90ce-c249e6843112 fwd="58.6.203.42,54.239.202.42" dyno=web.1 connect=0ms service=2ms status=304 bytes=112}
-              expect(socket.buffer[0]).to eq("heroku.router.connect:0.0|h|#env:production,service:myapp,source:web.1,dynotype:web,method:GET,path:/assets/admin-62f13e9f7cb78a2b3e436feaedd07fd67b74cce818f3bb7cfdab1e1c05dc2f89.css,status:304")
+              expect(socket.buffer[0]).to eq("heroku.router.connect:0.0|h|#env:production,service:myapp,source:web.1,dynotype:web,method:GET,status:304")
             end
           end
 


### PR DESCRIPTION
The router.connect and router.service metrics make up 85% of our current usage. Removing the tag for path should reduce this by a lot. Datadog APM and logging are much better solutions than a path tag is on these metrics.

https://buildkite.com/fivegoodfriends/heroku-drain-datadog/builds/66

<img width="1221" alt="Screen Shot 2021-08-02 at 14 05 19" src="https://user-images.githubusercontent.com/365913/127802986-88a5de66-e91c-4fd3-99ac-cf4101567592.png">
