### PR TITLE
Revert dogstatsd-ruby update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     byebug (11.1.3)
     diff-lcs (1.4.4)
-    dogstatsd-ruby (5.2.0)
+    dogstatsd-ruby (4.5.0)
     nio4r (2.5.7)
     puma (5.4.0)
       nio4r (~> 2.0)

--- a/spec/helpers/fake_udp_socket.rb
+++ b/spec/helpers/fake_udp_socket.rb
@@ -1,20 +1,16 @@
-# Copied from https://github.com/DataDog/dogstatsd-ruby/blob/master/spec/support/fake_udp_socket.rb
 class FakeUDPSocket
-  def initialize(copy_message: false)
+  attr_reader :buffer
+
+  def initialize
     @buffer = []
-    @error_on_send = nil
-    @copy_message = copy_message
   end
 
-  def send(message, *_)
-    raise @error_on_send if @error_on_send
-    message = message.dup if @copy_message
-
-    @buffer.push [message]
+  def send(message, *)
+    @buffer.push(message)
   end
 
-  def recv
-    @buffer.shift
+  def flush
+    @buffer.clear
   end
 
   def to_s
@@ -23,15 +19,5 @@ class FakeUDPSocket
 
   def inspect
     "<FakeUDPSocket: #{@buffer.inspect}>"
-  end
-
-  def error_on_send(err)
-    @error_on_send = err
-  end
-
-  def connect(*args)
-  end
-
-  def close
   end
 end


### PR DESCRIPTION
Expect this to resolve the Datadog monitor failure, _No data: Heroku Drain Datadog isn't forwarding any metrics_.