### PR TITLE
Add addon as a tag to Redis and Postgres metrics

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -137,6 +137,10 @@ redis:
       enabled: true
       type: integer
       metric: gauge
+  tags:
+    - heroku_name: addon
+      datadog_name: addon
+      type: string
 
 postgres:
   metrics:
@@ -215,3 +219,7 @@ postgres:
       enabled: true
       type: float
       metric: gauge
+  tags:
+    - heroku_name: addon
+      datadog_name: addon
+      type: string

--- a/spec/heroku_drain_datadog/http/router_spec.rb
+++ b/spec/heroku_drain_datadog/http/router_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe HerokuDrainDatadog::HTTP::Router do
 
         context "redis logs" do
           before do
-            post "/logs", %q{393 <134>1 2016-09-23T07:07:54+00:00 host app heroku-redis - source=REDIS sample#active-connections=27 sample#load-avg-1m=0 sample#load-avg-5m=0.015 sample#load-avg-15m=0.01 sample#read-iops=0 sample#write-iops=0.11282 sample#memory-total=15664876.0kB sample#memory-free=12688956.0kB sample#memory-cached=1762284.0kB sample#memory-redis=1908016bytes sample#hit-rate=0.0096774 sample#evicted-keys=0}
+            post "/logs", %q{393 <134>1 2016-09-23T07:07:54+00:00 host app heroku-redis - source=REDIS addon=redis-cubed-98704 sample#active-connections=27 sample#load-avg-1m=0 sample#load-avg-5m=0.015 sample#load-avg-15m=0.01 sample#read-iops=0 sample#write-iops=0.11282 sample#memory-total=15664876.0kB sample#memory-free=12688956.0kB sample#memory-cached=1762284.0kB sample#memory-redis=1908016bytes sample#hit-rate=0.0096774 sample#evicted-keys=0}
           end
 
           it "sends 13 metrics" do
@@ -143,51 +143,51 @@ RSpec.describe HerokuDrainDatadog::HTTP::Router do
           end
 
           it "sends a gauge for the active_connections" do
-            expect(socket.buffer[0]).to eq("heroku.redis.active_aconnections:27|g")
+            expect(socket.buffer[0]).to eq("heroku.redis.active_aconnections:27|g|#addon:redis-cubed-98704")
           end
 
           it "sends a gauge for the load_avg_1m" do
-            expect(socket.buffer[1]).to eq("heroku.redis.load_avg_1m:0.0|g")
+            expect(socket.buffer[1]).to eq("heroku.redis.load_avg_1m:0.0|g|#addon:redis-cubed-98704")
           end
 
           it "sends a gauge for the load_avg_5m" do
-            expect(socket.buffer[2]).to eq("heroku.redis.load_avg_5m:0.015|g")
+            expect(socket.buffer[2]).to eq("heroku.redis.load_avg_5m:0.015|g|#addon:redis-cubed-98704")
           end
 
           it "sends a gauge for the load_avg_15m" do
-            expect(socket.buffer[3]).to eq("heroku.redis.load_avg_15m:0.01|g")
+            expect(socket.buffer[3]).to eq("heroku.redis.load_avg_15m:0.01|g|#addon:redis-cubed-98704")
           end
 
           it "sends a gauge for the read_iops" do
-            expect(socket.buffer[4]).to eq("heroku.redis.read_iops:0.0|g")
+            expect(socket.buffer[4]).to eq("heroku.redis.read_iops:0.0|g|#addon:redis-cubed-98704")
           end
 
           it "sends a gauge for the write_iops" do
-            expect(socket.buffer[5]).to eq("heroku.redis.write_iops:0.11282|g")
+            expect(socket.buffer[5]).to eq("heroku.redis.write_iops:0.11282|g|#addon:redis-cubed-98704")
           end
 
           it "sends a gauge for the memory_total" do
-            expect(socket.buffer[6]).to eq("heroku.redis.memory_total:15664876.0|g")
+            expect(socket.buffer[6]).to eq("heroku.redis.memory_total:15664876.0|g|#addon:redis-cubed-98704")
           end
 
           it "sends a gauge for the memory_free" do
-            expect(socket.buffer[7]).to eq("heroku.redis.memory_free:12688956.0|g")
+            expect(socket.buffer[7]).to eq("heroku.redis.memory_free:12688956.0|g|#addon:redis-cubed-98704")
           end
 
           it "sends a gauge for the memory_cached" do
-            expect(socket.buffer[8]).to eq("heroku.redis.memory_cached:1762284.0|g")
+            expect(socket.buffer[8]).to eq("heroku.redis.memory_cached:1762284.0|g|#addon:redis-cubed-98704")
           end
 
           it "sends a gauge for the memory_redis" do
-            expect(socket.buffer[9]).to eq("heroku.redis.memory_redis:1908016.0|g")
+            expect(socket.buffer[9]).to eq("heroku.redis.memory_redis:1908016.0|g|#addon:redis-cubed-98704")
           end
 
           it "sends a gauge for the hit_rate" do
-            expect(socket.buffer[10]).to eq("heroku.redis.hit_rate:0.0096774|g")
+            expect(socket.buffer[10]).to eq("heroku.redis.hit_rate:0.0096774|g|#addon:redis-cubed-98704")
           end
 
           it "sends a gauge for the evicted_keys" do
-            expect(socket.buffer[11]).to eq("heroku.redis.evicted_keys:0|g")
+            expect(socket.buffer[11]).to eq("heroku.redis.evicted_keys:0|g|#addon:redis-cubed-98704")
           end
 
           it "increments drain" do
@@ -197,7 +197,7 @@ RSpec.describe HerokuDrainDatadog::HTTP::Router do
 
         context "postgres logs" do
           before do
-            post "/logs", %q{527 <134>1 2016-08-19T11:23:29+00:00 host app heroku-postgres - source=DATABASE sample#current_transaction=1947 sample#db_size=8945836.0bytes sample#tables=17 sample#active-connections=3 sample#waiting-connections=0 sample#index-cache-hit-rate=0.99396 sample#table-cache-hit-rate=0.99828 sample#load-avg-1m=0.02 sample#load-avg-5m=0.005 sample#load-avg-15m=0 sample#read-iops=0 sample#write-iops=0.011458 sample#memory-total=4045592.0kB sample#memory-free=1560288.0kB sample#memory-cached=1982288.0kB sample#memory-postgres=21292kB}
+            post "/logs", %q{527 <134>1 2016-08-19T11:23:29+00:00 host app heroku-postgres - source=DATABASE addon=postgres-parallel-38743 sample#current_transaction=1947 sample#db_size=8945836.0bytes sample#tables=17 sample#active-connections=3 sample#waiting-connections=0 sample#index-cache-hit-rate=0.99396 sample#table-cache-hit-rate=0.99828 sample#load-avg-1m=0.02 sample#load-avg-5m=0.005 sample#load-avg-15m=0 sample#read-iops=0 sample#write-iops=0.011458 sample#memory-total=4045592.0kB sample#memory-free=1560288.0kB sample#memory-cached=1982288.0kB sample#memory-postgres=21292kB}
           end
 
           it "sends 16 metrics" do
@@ -205,63 +205,63 @@ RSpec.describe HerokuDrainDatadog::HTTP::Router do
           end
 
           it "sends a gauge for db_size" do
-            expect(socket.buffer[0]).to eq("heroku.postgres.db_size:8945836.0|g")
+            expect(socket.buffer[0]).to eq("heroku.postgres.db_size:8945836.0|g|#addon:postgres-parallel-38743")
           end
 
           it "sends a gauge for tables" do
-            expect(socket.buffer[1]).to eq("heroku.postgres.tables:17|g")
+            expect(socket.buffer[1]).to eq("heroku.postgres.tables:17|g|#addon:postgres-parallel-38743")
           end
 
           it "sends a gauge for active_connections" do
-            expect(socket.buffer[2]).to eq("heroku.postgres.active_connections:3|g")
+            expect(socket.buffer[2]).to eq("heroku.postgres.active_connections:3|g|#addon:postgres-parallel-38743")
           end
 
           it "sends a gauge for waiting_connections" do
-            expect(socket.buffer[3]).to eq("heroku.postgres.waiting_connections:0|g")
+            expect(socket.buffer[3]).to eq("heroku.postgres.waiting_connections:0|g|#addon:postgres-parallel-38743")
           end
 
           it "sends a gauge for index_cache_hit_rate" do
-            expect(socket.buffer[4]).to eq("heroku.postgres.index_cache_hit_rate:0.99396|g")
+            expect(socket.buffer[4]).to eq("heroku.postgres.index_cache_hit_rate:0.99396|g|#addon:postgres-parallel-38743")
           end
 
           it "sends a gauge for table_cache_hit_rate" do
-            expect(socket.buffer[5]).to eq("heroku.postgres.table_cache_hit_rate:0.99828|g")
+            expect(socket.buffer[5]).to eq("heroku.postgres.table_cache_hit_rate:0.99828|g|#addon:postgres-parallel-38743")
           end
 
           it "sends a gauge for load_avg_1m" do
-            expect(socket.buffer[6]).to eq("heroku.postgres.load_avg_1m:0.02|g")
+            expect(socket.buffer[6]).to eq("heroku.postgres.load_avg_1m:0.02|g|#addon:postgres-parallel-38743")
           end
 
           it "sends a gauge for load_avg_5m" do
-            expect(socket.buffer[7]).to eq("heroku.postgres.load_avg_5m:0.005|g")
+            expect(socket.buffer[7]).to eq("heroku.postgres.load_avg_5m:0.005|g|#addon:postgres-parallel-38743")
           end
 
           it "sends a gauge for load_avg_15m" do
-            expect(socket.buffer[8]).to eq("heroku.postgres.load_avg_15m:0.0|g")
+            expect(socket.buffer[8]).to eq("heroku.postgres.load_avg_15m:0.0|g|#addon:postgres-parallel-38743")
           end
 
           it "sends a gauge for read_iops" do
-            expect(socket.buffer[9]).to eq("heroku.postgres.read_iops:0.0|g")
+            expect(socket.buffer[9]).to eq("heroku.postgres.read_iops:0.0|g|#addon:postgres-parallel-38743")
           end
 
           it "sends a gauge for write_iops" do
-            expect(socket.buffer[10]).to eq("heroku.postgres.write_iops:0.011458|g")
+            expect(socket.buffer[10]).to eq("heroku.postgres.write_iops:0.011458|g|#addon:postgres-parallel-38743")
           end
 
           it "sends a gauge for memory_total" do
-            expect(socket.buffer[11]).to eq("heroku.postgres.memory_total:4045592.0|g")
+            expect(socket.buffer[11]).to eq("heroku.postgres.memory_total:4045592.0|g|#addon:postgres-parallel-38743")
           end
 
           it "sends a gauge for memory_free" do
-            expect(socket.buffer[12]).to eq("heroku.postgres.memory_free:1560288.0|g")
+            expect(socket.buffer[12]).to eq("heroku.postgres.memory_free:1560288.0|g|#addon:postgres-parallel-38743")
           end
 
           it "sends a gauge for memory_cached" do
-            expect(socket.buffer[13]).to eq("heroku.postgres.memory_cached:1982288.0|g")
+            expect(socket.buffer[13]).to eq("heroku.postgres.memory_cached:1982288.0|g|#addon:postgres-parallel-38743")
           end
 
           it "sends a gauge for memory_postgres" do
-            expect(socket.buffer[14]).to eq("heroku.postgres.memory_postgres:21292.0|g")
+            expect(socket.buffer[14]).to eq("heroku.postgres.memory_postgres:21292.0|g|#addon:postgres-parallel-38743")
           end
 
           it "increments drain" do

--- a/spec/heroku_drain_datadog/parser_spec.rb
+++ b/spec/heroku_drain_datadog/parser_spec.rb
@@ -4,8 +4,8 @@ require "heroku_drain_datadog/parser"
 RSpec.describe HerokuDrainDatadog::Parser do
   let(:router_log) { %q{338 <158>1 2016-08-20T02:15:10.862264+00:00 host heroku router - at=info method=GET path="/assets/admin-62f13e9f7cb78a2b3e436feaedd07fd67b74cce818f3bb7cfdab1e1c05dc2f89.css" host=app.fivegoodfriends.com.au request_id=bef7f609-eceb-4684-90ce-c249e6843112 fwd="58.6.203.42,54.239.202.42" dyno=web.1 connect=0ms service=2ms status=304 bytes=112} }
   let(:dyno_log) { %q{334 <45>1 2016-08-19T11:23:01.581780+00:00 host heroku web.1 - source=web.1 dyno=heroku.54241834.4b88c98d-6243-4194-af49-8db9b53be371 sample#memory_total=154.85MB sample#memory_rss=139.79MB sample#memory_cache=3.63MB sample#memory_swap=11.43MB sample#memory_pgpgin=80522pages sample#memory_pgpgout=53004pages sample#memory_quota=512.00MB} }
-  let(:redis_log) { %q{393 <134>1 2016-09-23T07:07:54+00:00 host app heroku-redis - source=REDIS sample#active-connections=27 sample#load-avg-1m=0 sample#load-avg-5m=0.015 sample#load-avg-15m=0.01 sample#read-iops=0 sample#write-iops=0.11282 sample#memory-total=15664876.0kB sample#memory-free=12688956.0kB sample#memory-cached=1762284.0kB sample#memory-redis=1908016bytes sample#hit-rate=0.0096774 sample#evicted-keys=0} }
-  let(:postgres_log) { %q{527 <134>1 2016-08-19T11:23:29+00:00 host app heroku-postgres - source=DATABASE sample#current_transaction=1947 sample#db_size=8945836.0bytes sample#tables=17 sample#active-connections=3 sample#waiting-connections=0 sample#index-cache-hit-rate=0.99396 sample#table-cache-hit-rate=0.99828 sample#load-avg-1m=0.02 sample#load-avg-5m=0.005 sample#load-avg-15m=0 sample#read-iops=0 sample#write-iops=0.011458 sample#memory-total=4045592.0kB sample#memory-free=1560288.0kB sample#memory-cached=1982288.0kB sample#memory-postgres=21292kB} }
+  let(:redis_log) { %q{393 <134>1 2016-09-23T07:07:54+00:00 host app heroku-redis - source=REDIS addon=redis-cubed-98704 sample#active-connections=27 sample#load-avg-1m=0 sample#load-avg-5m=0.015 sample#load-avg-15m=0.01 sample#read-iops=0 sample#write-iops=0.11282 sample#memory-total=15664876.0kB sample#memory-free=12688956.0kB sample#memory-cached=1762284.0kB sample#memory-redis=1908016bytes sample#hit-rate=0.0096774 sample#evicted-keys=0} }
+  let(:postgres_log) { %q{527 <134>1 2016-08-19T11:23:29+00:00 host app heroku-postgres - source=DATABASE addon=postgres-parallel-38743 sample#current_transaction=1947 sample#db_size=8945836.0bytes sample#tables=17 sample#active-connections=3 sample#waiting-connections=0 sample#index-cache-hit-rate=0.99396 sample#table-cache-hit-rate=0.99828 sample#load-avg-1m=0.02 sample#load-avg-5m=0.005 sample#load-avg-15m=0 sample#read-iops=0 sample#write-iops=0.011458 sample#memory-total=4045592.0kB sample#memory-free=1560288.0kB sample#memory-cached=1982288.0kB sample#memory-postgres=21292kB} }
 
   context "dyno logs" do
     let(:log_entry) { subject.call(dyno_log).first }
@@ -63,6 +63,7 @@ RSpec.describe HerokuDrainDatadog::Parser do
     it "has data" do
       expect(log_entry.data).to eq({
         "source" => "REDIS",
+        "addon"=>"redis-cubed-98704",
         "sample#active-connections" => "27",
         "sample#load-avg-1m" => "0",
         "sample#load-avg-5m" => "0.015",
@@ -89,6 +90,7 @@ RSpec.describe HerokuDrainDatadog::Parser do
     it "has data" do
       expect(log_entry.data).to eq({
         "source" => "DATABASE",
+        "addon"=>"postgres-parallel-38743",
         "sample#current_transaction" => "1947",
         "sample#db_size" => "8945836.0bytes",
         "sample#tables" => "17",


### PR DESCRIPTION
There can be more than one Redis or Postgres database per app. This allows for those individual metrics to be analyzed separately.